### PR TITLE
Fix querying weather using automatic location with negative latitude

### DIFF
--- a/core/src/main/java/ru/gelin/android/weather/openweathermap/OpenWeatherMapSource.java
+++ b/core/src/main/java/ru/gelin/android/weather/openweathermap/OpenWeatherMapSource.java
@@ -60,11 +60,11 @@ public class OpenWeatherMapSource extends HttpWeatherSource implements WeatherSo
         if (location == null) {
             throw new WeatherException("null location");
         }
-        if (location.getText().startsWith("-")) {
-            return new TestWeather(Integer.parseInt(location.getText()));
+        if (location.getText().startsWith("_TEST_-")) {
+            return new TestWeather(Integer.parseInt(location.getText().substring(6)));
         }
-        if (location.getText().startsWith("+")) {
-            return new TestWeather(Integer.parseInt(location.getText().substring(1)));
+        if (location.getText().startsWith("_TEST_+")) {
+            return new TestWeather(Integer.parseInt(location.getText().substring(7)));
         }
 
         OpenWeatherMapWeather weather = new OpenWeatherMapWeather(this.context);

--- a/core/src/test/java/ru/gelin/android/weather/openweathermap/OpenWeatherMapSourceTest.java
+++ b/core/src/test/java/ru/gelin/android/weather/openweathermap/OpenWeatherMapSourceTest.java
@@ -92,7 +92,7 @@ public class OpenWeatherMapSourceTest {
     @Test
     public void testQueryTestLocationPlus() throws WeatherException {
         WeatherSource source = new OpenWeatherMapSource(context);
-        Location location = new SimpleLocation("+25", false);
+        Location location = new SimpleLocation("_TEST_+25", false);
         Weather weather = source.query(location);
         assertNotNull(weather);
         assertFalse(weather.isEmpty());
@@ -103,7 +103,7 @@ public class OpenWeatherMapSourceTest {
     @Test
     public void testQueryTestLocationMinus() throws WeatherException {
         WeatherSource source = new OpenWeatherMapSource(context);
-        Location location = new SimpleLocation("-25", false);
+        Location location = new SimpleLocation("_TEST_-25", false);
         Weather weather = source.query(location);
         assertNotNull(weather);
         assertFalse(weather.isEmpty());


### PR DESCRIPTION
If a location string started with "-", `OpenWeatherMapSource#query` would return a `TestWeather` for unit testing purposes, and not query OpenWeatherMap. This caused a problem where locations with a negative latitude would fall into the `TestWeather` case, as the string would begin with "-". As a result, automatic location detection did not work in such locations (i.e. the Southern Hemisphere).

This PR changes the prefix to "\_TEST_-" (and also changes the other case to "\_TEST_+" for consistency), so that locations with a negative latitude don't fall into the unit testing case.

Should fix #40.